### PR TITLE
Update base CentOS AMI to one that we can make public

### DIFF
--- a/environment.aws
+++ b/environment.aws
@@ -2,7 +2,7 @@
 export AWS_ACCESS_KEY_ID="changeme"
 export AWS_SECRET_ACCESS_KEY="changeme"
 export AWS_REGION=us-east-1
-export AWS_SOURCE_AMI=ami-d5bf2caa
+export AWS_SOURCE_AMI=ami-ec377793
 export AWS_BUILD_INSTANCE_TYPE=t2.medium
 export AWS_SUBNET_ID=changeme
 export AWS_SECURITY_GROUP_ID=changeme


### PR DESCRIPTION
Created a base CentOS AMI that does not include the marketplace
product code. This will allow us to make our AMIs public.