### PR TITLE
Playbook to terminate test instance

### DIFF
--- a/ec2-test-centos-cleanup.yml
+++ b/ec2-test-centos-cleanup.yml
@@ -1,0 +1,14 @@
+- hosts: localhost
+  connection: local
+  gather_facts: False
+  vars:
+    aws_key_name: "{{ lookup('env', 'AWS_KEY_NAME') }}"
+    aws_instance_name: "{{ lookup('env', 'AWS_INSTANCE_NAME') }}"
+    aws_subnet_id: "{{ lookup('env', 'AWS_SUBNET_ID') }}"
+  tasks:
+    - name: stop test ec2 instance
+      ec2_instance:
+        key_name: "{{ aws_key_name }}"
+        vpc_subnet_id: "{{ aws_subnet_id }}"
+        name: "{{ aws_instance_name }}"
+        state: absent


### PR DESCRIPTION
The playbook should be executed after ec2-test-centos.yml to
terminate the ec2 instance that may have been created during
the test.