### PR TITLE
Publish AMI to all AWS region

### DIFF
--- a/aws-ami-publish.yml
+++ b/aws-ami-publish.yml
@@ -1,0 +1,77 @@
+- hosts: localhost
+  connection: local
+  gather_facts: False
+  vars:
+    aws_key_name: "{{ lookup('env', 'AWS_KEY_NAME') }}"
+    aws_ami: "{{ lookup('env', 'AWS_TEST_AMI') }}"
+    aws_region: "{{ lookup('env', 'AWS_REGION') }}"
+  tasks:
+    # Assumes this playbook is executed in the same environment
+    # as the build and test pipeline. This means the packer
+    # build manifest is available in the file system.
+  
+    - name: read build artifact
+      include_vars: 
+        file: packer-build-manifest.json 
+        name: build_artifact
+
+    - name: print ami_id
+      set_fact: region_ami_ids={{ build_artifact['builds'][0].artifact_id }}
+
+    - name: print
+      debug: var=region_ami_ids
+
+    - name: set region and ami_id
+      set_fact: aws_region={{ region_ami_ids.split(':')[0] }}
+      set_fact: aws_ami={{ region_ami_ids.split(':')[1] }}
+
+    - name: make source AMI public
+      ec2_ami:
+        image_id: "{{ aws_ami }}"
+        state: present
+        launch_permissions:
+          group_names: ['all']
+      register: source_ami_details
+
+    - name: copy the source AMI to other regions
+      ec2_ami_copy:
+        source_region: us-east-1
+        region: "{{ item }}"
+        source_image_id: "{{ aws_ami }}"
+        wait: yes
+        wait_timeout: 1200  # Default timeout is 600
+        name: "{{ source_ami_details.name }}"
+        tags: "{{ source_ami_details.tags }}"
+      register: published_ami_ids
+      with_items:
+        - us-east-2
+        - us-west-1
+        - us-west-2
+        - ap-northeast-1
+        - ap-northeast-2
+        - ap-northeast-3
+        - ap-south-1
+        - ap-southeast-1
+        - ap-southeast-2
+        - ca-central-1
+        - eu-central-1
+        - eu-west-1
+        - eu-west-2
+        - eu-west-3
+        - sa-east-1
+        
+    - name: make published AMIs public
+      ec2_ami:
+        image_id: "{{ item.image_id }}"
+        region: "{{ item.item }}"
+        state: present
+        launch_permissions:
+          group_names: ['all']
+      with_items: "{{ published_ami_ids.results }}"
+
+    - name: record source AMI
+      shell: echo "{{ aws_region }}:{{ aws_ami }}" >> published-aws-image-ids 
+
+    - name: record published AMIs
+      shell: echo "{{ item.item }}:{{ item.image_id }}" >> published-aws-image-ids
+      with_items: "{{ published_ami_ids.results }}"


### PR DESCRIPTION
Uses packer build manifest from test step.

The source and published image are made public.

Creates a file called published-aws-image-ids which contains a list
of <region>:<ami_id>.