### PR TITLE
Use KubeVirt 0.8.0-alpha.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,12 @@ set -x
 cd image-files
 if [ ! -d kubevirt-ansible ]; then
   git clone https://github.com/kubevirt/kubevirt-ansible
-  sed -i 's@apply -f /tmp/kubevirt.yaml@apply -f /tmp/kubevirt.yaml --validate=false@' kubevirt-ansible/roles/kubevirt/tasks/provision.yml
-  sed -i "s@kubectl taint nodes {{ ansible_fqdn }} node-role.kubernetes.io/master:NoSchedule- || :@kubectl taint nodes --all node-role.kubernetes.io/master-@"  kubevirt-ansible/roles/kubernetes-master/templates/deploy_kubernetes.j2
+
+  # TODO: Remove after kubevirt-ansible has moved to 0.8.0.
+  sed -i 's@version: 0.7.0@version: 0.8.0-alpha.0@' kubevirt-ansible/vars/all.yml
+  # TODO: Remove after it has been added to kubevirt-ansible.
+  # New parameter added with 0.8.0-alpha.0
+  echo "image_pull_policy: IfNotPresent" >> kubevirt-ansible/roles/kubevirt/defaults/main.yml
 fi
 
 export KUBEVIRT_VERSION=$(cat kubevirt-ansible/vars/all.yml | grep version | grep -v _ver | cut -f 2 -d ' ')

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ set -x
 cd image-files
 if [ ! -d kubevirt-ansible ]; then
   git clone https://github.com/kubevirt/kubevirt-ansible
+  sed -i "s@kubectl taint nodes {{ ansible_fqdn }} node-role.kubernetes.io/master:NoSchedule- || :@kubectl taint nodes --all node-role.kubernetes.io/master-@"  kubevirt-ansible/roles/kubernetes-master/templates/deploy_kubernetes.j2
 
   # TODO: Remove after kubevirt-ansible has moved to 0.8.0.
   sed -i 's@version: 0.7.0@version: 0.8.0-alpha.0@' kubevirt-ansible/vars/all.yml


### PR DESCRIPTION
Forces kubevirt-ansible to use 0.8.0-alpha.0.

This version of KubeVirt fixes compatibility issues with K8S v1.11
and issues with missing tun devices when /dev/kvm is missing.