### PR TITLE
Add back motd and emulation-configmap for aws

### DIFF
--- a/kubevirt-ami-centos.json
+++ b/kubevirt-ami-centos.json
@@ -78,6 +78,21 @@
     {
       "type": "shell",
       "inline": "sudo yum update -y"
+    },
+    {
+      "type": "file",
+      "source": "image-files/motd.j2",
+      "destination": "/home/centos/"
+    },
+    {
+      "type": "file",
+      "source": "image-files/motd.yml",
+      "destination": "/home/centos/"
+    },
+    {
+      "type": "file",
+      "source": "image-files/emulation-configmap.yaml",
+      "destination": "/home/centos/"
     }
   ],
   "post-processors": [


### PR DESCRIPTION
They got lost during the ci pipeline merge.