### PR TITLE
Fix AWS build instance name

### DIFF
--- a/kubevirt-ami-centos.json
+++ b/kubevirt-ami-centos.json
@@ -22,7 +22,10 @@
     "ami_name": "{{user `aws_instance_name`}}",
     "subnet_id": "{{user `subnet_id`}}",
     "associate_public_ip_address": "true",
-    "security_group_id": "{{user `security_group`}}"
+    "security_group_id": "{{user `security_group`}}",
+    "run_tags": {
+       "Name": "{{user `aws_instance_name`}}"
+    }
   }],
   "provisioners": [
     {


### PR DESCRIPTION
The instance name was not being set during image build, so it
defaulted to "Packer Builder". The name needs to be unique
in the event multiple PRs trigger multiple CI builds.