### PR TITLE
Parameterize GCP instance name

### DIFF
--- a/gcp-test-centos-cleanup.yml
+++ b/gcp-test-centos-cleanup.yml
@@ -2,7 +2,7 @@
   connection: local
   gather_facts: False
   vars:
-    gcp_instance_name: "my-test-instance1"
+    gcp_instance_name: "{{ lookup('env', 'IMAGE_NAME') }}"
     credentials_file: "{{ lookup('env', 'GOOGLE_APPLICATION_CREDENTIALS') }}"
     project_id: "{{ lookup('env', 'PROJECT_ID') }}"
     zone: "{{ lookup('env', 'ZONE') }}"

--- a/gcp-test-centos.yml
+++ b/gcp-test-centos.yml
@@ -9,6 +9,7 @@
     zone: "{{ lookup('env', 'ZONE') }}"
     service_account_email:  "{{ lookup('env', 'SERVICE_ACCOUNT_EMAIL') }}"
     ssh_public_key: "{{ lookup('file', lookup('env', 'GCP_SSH_PUBLIC_KEY')) }}"
+    instance_name: "{{ lookup('env', 'IMAGE_NAME') }}",
   tasks:
     - name: Read build artifact
       include_vars:
@@ -20,7 +21,7 @@
 
     - name: Provision the test instance
       gce:
-         instance_names: my-test-instance1
+         instance_names: "{{ instance_name }}"
          zone: "{{ zone }}"
          machine_type: "{{ machine_type }}"
          image: "{{ image }}"

--- a/gcp-test-centos.yml
+++ b/gcp-test-centos.yml
@@ -9,7 +9,7 @@
     zone: "{{ lookup('env', 'ZONE') }}"
     service_account_email:  "{{ lookup('env', 'SERVICE_ACCOUNT_EMAIL') }}"
     ssh_public_key: "{{ lookup('file', lookup('env', 'GCP_SSH_PUBLIC_KEY')) }}"
-    instance_name: "{{ lookup('env', 'IMAGE_NAME') }}",
+    instance_name: "{{ lookup('env', 'IMAGE_NAME') }}"
   tasks:
     - name: Read build artifact
       include_vars:

--- a/kubevirt-gcp-centos.json
+++ b/kubevirt-gcp-centos.json
@@ -17,7 +17,7 @@
       "disk_size": "{{user `disk_size`}}",
       "image_description": "Kubevirt button based on {{user `kubevirt_version`}}",
       "image_name": "{{user `image_name`}}",
-      "instance_name": "kubevirt-pipeline",
+      "instance_name": "{{user `image_name`}}",
       "machine_type": "{{user `machine_type`}}",
       "ssh_username": "centos",
       "zone": "{{user `zone`}}",


### PR DESCRIPTION
Instance name needs to be unique for each PR and tagged release,
because multiple CI builds can run concurrently.

Image name is used as the instance name. Assumes instance name
contains PR # and build #. A PR can trigger multiple builds.