### PR TITLE
Replace '.' with '-' in image names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ images.each { imageName, imageValues ->
 
                             // modify any parameters
                             imageParam = env.TAG_NAME ?: (env.BRANCH_NAME ?: 'master')
-                            imageParam = "${imageParam}-build-${env.BUILD_NUMBER}"
+                            imageParam = "${imageParam}-build-${env.BUILD_NUMBER}".replaceAll('\\.','-')
                             params['IMAGE_NAME'] = "${params['IMAGE_NAME']}-${imageParam.toLowerCase()}"
                         }
                     }


### PR DESCRIPTION
GCP doesn't allow periods in image names.