### PR TITLE
Have CI also archive published-aws-image-ids

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ images.each { imageName, imageValues ->
 
         def archives = {
             step([$class   : 'ArtifactArchiver', allowEmptyArchive: true,
-                  artifacts: 'packer-build-*.json', fingerprint: true])
+                  artifacts: 'packer-build-*.json,published-aws-image-ids', fingerprint: true])
         }
 
         deployOpenShiftTemplate(containersWithProps: containers, openshift_namespace: 'kubevirt', podName: podName,


### PR DESCRIPTION
published-aws-image-ids is a file containing the AMI ids and regions
that were published. This should be archived.