### PR TITLE
Determine KubeVirt version for GCP publish

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,8 @@ chmod +x virtctl
 
 cp cluster-localhost.yml kubevirt-ansible/playbooks/cluster/kubernetes
 cd ..
+echo $KUBEVIRT_VERSION > kubevirt-version
+pwd
 
 $PACKER build -debug -machine-readable --force $PACKER_BUILD_TEMPLATE | tee build.log
 echo "AWS_TEST_AMI=`egrep -m1 -oe 'ami-.{8}' build.log`" >> job.props

--- a/gcp-image-publish.yml
+++ b/gcp-image-publish.yml
@@ -91,11 +91,25 @@
   vars:
     user: "centos"
     bucket: "kubevirt-button"
-    version: "v0.7.1"
+    version: "tbd"
   user: centos
   become: True
   gather_facts: True
   tasks:
+    - name: copy kubevirt-version
+      copy:
+        src: kubevirt-version
+        dest: "/home/{{ user }}/kubevirt-version"
+        owner: "{{ user }}"
+        group: centos
+
+    - name: read kubevirt-version file
+      shell: cat kubevirt-version
+      register: kubevirt_version
+      
+    - name: set version variable
+      set_fact: version="v{{ kubevirt_version.stdout }}"
+
     - name: Copy Publisher Script
       template:
         src: gcp-image-publish.sh.j2


### PR DESCRIPTION
The version number was hard-coded. The version number should be
determined from what kubevirt-ansbile will install.