### PR TITLE
Clean up images built during PR validation

### DIFF
--- a/ec2-test-centos-cleanup.yml
+++ b/ec2-test-centos-cleanup.yml
@@ -5,6 +5,7 @@
     aws_key_name: "{{ lookup('env', 'AWS_KEY_NAME') }}"
     aws_instance_name: "{{ lookup('env', 'IMAGE_NAME') }}"
     aws_subnet_id: "{{ lookup('env', 'AWS_SUBNET_ID') }}"
+    build_tag_name: "{{ lookup('env', 'TAG_NAME') }}"
   tasks:
     - name: stop test ec2 instance
       ec2_instance:
@@ -12,3 +13,12 @@
         vpc_subnet_id: "{{ aws_subnet_id }}"
         name: "{{ aws_instance_name }}"
         state: absent
+
+    - include_tasks: read-packer-manifest-aws.yml
+
+    - name: delete image if this is not a release build
+      ec2_ami:
+        image_id: "{{ aws_ami }}"
+        delete_snapshot: true
+        state: absent
+      when: build_tag_name == ""

--- a/ec2-test-centos.yml
+++ b/ec2-test-centos.yml
@@ -17,20 +17,7 @@
         name: "{{ aws_instance_name }}"
         state: absent
 
-    - name: read build artifact
-      include_vars:
-        file: packer-build-manifest-aws.json
-        name: build_artifact
-
-    - name: print ami_id
-      set_fact: region_ami_ids={{ build_artifact['builds'][0].artifact_id }}
-
-    - name: print
-      debug: var=region_ami_ids
-
-    - name: set region and ami_id
-      set_fact: aws_region={{ region_ami_ids.split(':')[0] }}
-      set_fact: aws_ami={{ region_ami_ids.split(':')[1] }}
+    - include_tasks: read-packer-manifest-aws.yml
 
     - name: Provision the test instance
       ec2:

--- a/gcp-test-centos-cleanup.yml
+++ b/gcp-test-centos-cleanup.yml
@@ -7,6 +7,7 @@
     project_id: "{{ lookup('env', 'PROJECT_ID') }}"
     zone: "{{ lookup('env', 'ZONE') }}"
     service_account_email:  "{{ lookup('env', 'SERVICE_ACCOUNT_EMAIL') }}"
+    build_tag_name: "{{ lookup('env', 'TAG_NAME') }}"
   tasks:
     - name: wait for instance to shutdown
       gcp_compute_instance_facts:
@@ -34,3 +35,15 @@
          service_account_email: "{{ service_account_email }}"
          credentials_file: "{{ credentials_file }}"
          project_id: "{{ project_id }}"
+
+    - include_tasks: read-packer-manifest-gcp.yml
+
+    - name: delete image if this is not a release build
+      gce_img:
+        name: "{{ image }}"
+        state: absent
+        zone: "{{ zone }}"
+        service_account_email: "{{ service_account_email }}"
+        pem_file: "{{ credentials_file }}"
+        project_id: "{{ project_id }}"
+      when: build_tag_name == ""

--- a/gcp-test-centos.yml
+++ b/gcp-test-centos.yml
@@ -11,13 +11,7 @@
     ssh_public_key: "{{ lookup('file', lookup('env', 'GCP_SSH_PUBLIC_KEY')) }}"
     instance_name: "{{ lookup('env', 'IMAGE_NAME') }}"
   tasks:
-    - name: Read build artifact
-      include_vars:
-        file: packer-build-manifest-gcp.json
-        name: build_artifact
-
-    - name: Set Push Button Image Name
-      set_fact: image={{ build_artifact['builds'][0].artifact_id }}
+    - include_tasks: read-packer-manifest-gcp.yml
 
     - name: Provision the test instance
       gce:

--- a/read-packer-manifest-aws.yml
+++ b/read-packer-manifest-aws.yml
@@ -1,0 +1,14 @@
+- name: read build artifact
+  include_vars:
+    file: packer-build-manifest-aws.json
+    name: build_artifact
+
+- name: print ami_id
+  set_fact: region_ami_ids={{ build_artifact['builds'][0].artifact_id }}
+
+- name: print
+  debug: var=region_ami_ids
+
+- name: set region and ami_id
+  set_fact: aws_region={{ region_ami_ids.split(':')[0] }}
+  set_fact: aws_ami={{ region_ami_ids.split(':')[1] }}

--- a/read-packer-manifest-gcp.yml
+++ b/read-packer-manifest-gcp.yml
@@ -1,0 +1,7 @@
+- name: Read build artifact
+  include_vars:
+    file: packer-build-manifest-gcp.json
+    name: build_artifact
+
+- name: Set Push Button Image Name
+  set_fact: image={{ build_artifact['builds'][0].artifact_id }}


### PR DESCRIPTION
The images built by the CI to validate pull requests can be deleted
during the cleanup setup. They are not meant to be consumed by the
public. Currently, they are not deleted and just accumulate after the CI
run.

Fixes issue https://github.com/kubevirt/cloud-image-builder/issues/53