### PR TITLE
Fix kubevirt ansible and multus issues

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,8 +6,8 @@ if [ ! -d kubevirt-ansible ]; then
   git clone https://github.com/kubevirt/kubevirt-ansible
   sed -i "s@kubectl taint nodes {{ ansible_fqdn }} node-role.kubernetes.io/master:NoSchedule- || :@kubectl taint nodes --all node-role.kubernetes.io/master-@"  kubevirt-ansible/roles/kubernetes-master/templates/deploy_kubernetes.j2
 
-  # TODO: Remove after kubevirt-ansible has moved to 0.8.0.
-  sed -i 's@version: 0.8.0-alpha.1@version: 0.8.0@' kubevirt-ansible/vars/all.yml
+  #Remove when this PR is merge: https://github.com/kubevirt/kubevirt-ansible/pull/399
+  echo "  when: cli.stdout == \"oc\"" >> kubevirt-ansible/roles/cdi/tasks/provision.yml
 fi
 
 export KUBEVIRT_VERSION=$(cat kubevirt-ansible/vars/all.yml | grep version | grep -v _ver | cut -f 2 -d ' ')

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,9 @@ if [ ! -d kubevirt-ansible ]; then
 
   #Remove when this PR is merge: https://github.com/kubevirt/kubevirt-ansible/pull/399
   echo "  when: cli.stdout == \"oc\"" >> kubevirt-ansible/roles/cdi/tasks/provision.yml
+
+  #TODO: remove when PR to update multus config to use weave-net instead of flannel is merged
+  cp multus-config.yml kubevirt-ansible/roles/network-multus/defaults/main.yml
 fi
 
 export KUBEVIRT_VERSION=$(cat kubevirt-ansible/vars/all.yml | grep version | grep -v _ver | cut -f 2 -d ' ')

--- a/image-files/multus-config.yml
+++ b/image-files/multus-config.yml
@@ -1,0 +1,35 @@
+namespace: "kube-system"
+cluster: "kubernetes"
+apb_action: "provision"
+
+multus_provisioner_repo: "docker.io/nfvpe/multus"
+multus_provisioner_release: "latest"
+
+cni_provisioner_repo: "quay.io/schseba/cni-plugins"
+cni_provisioner_release: "latest"
+
+openshift_cni_config: |
+  '{
+    "name": "multus-cni-network",
+    "type": "multus",
+    "delegates": [{
+      "type": "openshift-sdn",
+      "name": "openshift.1",
+      "masterplugin": true
+    }],
+    "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"
+  }'
+
+kubernetes_cni_config: |
+  '{
+    "name": "multus-cni-network",
+    "type": "multus",
+    "delegates": [
+     {
+       "type": "weave-net",
+       "name": "weave-net.1",
+       "hairpinMode": true
+     }
+    ],
+    "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"
+  }'

--- a/kubevirt-ami-centos.json
+++ b/kubevirt-ami-centos.json
@@ -76,6 +76,10 @@
     },
     {
       "type": "shell",
+      "inline": "sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+    },
+    {
+      "type": "shell",
       "inline": "sudo yum install -y ansible docker jq bind-utils bind-libs cockpit wget git"
     },
     {


### PR DESCRIPTION
Recent changes in kubevirt-ansible has broken upstream kubernetes deployments. The fixes in this patch include:
1. An update to use Ansible version 2.6, so that multus provisioning does fail on a field loop issue. (https://github.com/kubevirt/cloud-image-builder/issues/59)
2. An update to the cdi provisioning to skip a step that only should run on OpenShift. (https://github.com/kubevirt/kubevirt-ansible/issues/398)
3. An update to the multus config file so that it uses the weave-net instead of flannel. 
(https://github.com/kubevirt/kubevirt-ansible/issues/401)

2 & 3 should be removed once kubevirt-ansible is updated with the appropriate fix.

Fixes issue https://github.com/kubevirt/cloud-image-builder/issues/59