### PR TITLE
Fix symbolic links in kubevirt-ansible

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -x
 
-cd image-files
 if [ ! -d kubevirt-ansible ]; then
   git clone https://github.com/kubevirt/kubevirt-ansible
   sed -i "s@kubectl taint nodes {{ ansible_fqdn }} node-role.kubernetes.io/master:NoSchedule- || :@kubectl taint nodes --all node-role.kubernetes.io/master-@"  kubevirt-ansible/roles/kubernetes-master/templates/deploy_kubernetes.j2
@@ -10,15 +9,13 @@ if [ ! -d kubevirt-ansible ]; then
   echo "  when: cli.stdout == \"oc\"" >> kubevirt-ansible/roles/cdi/tasks/provision.yml
 
   #TODO: remove when PR to update multus config to use weave-net instead of flannel is merged
-  cp multus-config.yml kubevirt-ansible/roles/network-multus/defaults/main.yml
+  cp image-files/multus-config.yml kubevirt-ansible/roles/network-multus/defaults/main.yml
 fi
 
 export KUBEVIRT_VERSION=$(cat kubevirt-ansible/vars/all.yml | grep version | grep -v _ver | cut -f 2 -d ' ')
 [ -f virtctl ] || curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v$KUBEVIRT_VERSION/virtctl-v$KUBEVIRT_VERSION-linux-amd64
 chmod +x virtctl
 
-cp cluster-localhost.yml kubevirt-ansible/playbooks/cluster/kubernetes
-cd ..
 echo $KUBEVIRT_VERSION > kubevirt-version
 pwd
 

--- a/kubevirt-ami-centos.json
+++ b/kubevirt-ami-centos.json
@@ -29,77 +29,35 @@
   }],
   "provisioners": [
     {
-      "type": "file",
-      "source": "image-files/kubevirt-ansible",
-      "destination": "/home/centos"
+      "type": "shell-local",
+      "command": "tar czf ./image-files/kubevirt-ansible.tar.gz kubevirt-ansible"
     },
     {
       "type": "file",
-      "source": "image-files/cluster-wait.yml",
+      "source": "image-files",
       "destination": "/home/centos/"
     },
     {
-      "type": "file",
-      "source": "image-files/virtctl",
-      "destination": "/home/centos/"
-    },
-    {
-      "type": "file",
-      "source": "tests",
-      "destination": "/home/centos"
-    },
-    {
-      "type": "file",
-      "source": "image-files/kubevirt-installer.service",
-      "destination": "/home/centos/"
+      "type": "shell-local",
+      "command": "rm ./image-files/kubevirt-ansible.tar.gz"
     },
     {
       "type": "shell",
-      "inline": "sudo mv /home/centos/kubevirt-installer.service /usr/lib/systemd/system/"
-    },
-    {
-      "type": "file",
-      "source": "image-files/first-boot-centos.sh",
-      "destination": "/home/centos/first-boot.sh"
-    },
-    {
-      "type": "shell",
-      "inline": "sudo mv /home/centos/first-boot.sh /usr/local/bin/"
-    },
-    {
-      "type": "shell",
-      "inline": "sudo systemctl daemon-reload"
-    },
-    {
-      "type": "shell",
-      "inline": "sudo systemctl enable kubevirt-installer"
-    },
-    {
-      "type": "shell",
-      "inline": "sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-    },
-    {
-      "type": "shell",
-      "inline": "sudo yum install -y ansible docker jq bind-utils bind-libs cockpit wget git"
-    },
-    {
-      "type": "shell",
-      "inline": "sudo yum update -y"
-    },
-    {
-      "type": "file",
-      "source": "image-files/motd.j2",
-      "destination": "/home/centos/"
-    },
-    {
-      "type": "file",
-      "source": "image-files/motd.yml",
-      "destination": "/home/centos/"
-    },
-    {
-      "type": "file",
-      "source": "image-files/emulation-configmap.yaml",
-      "destination": "/home/centos/"
+      "inline": [
+        "mv image-files/* .",
+        "rmdir image-files",
+        "tar xzf kubevirt-ansible.tar.gz",
+        "rm kubevirt-ansible.tar.gz",
+        "sudo mv /home/centos/kubevirt-installer.service /usr/lib/systemd/system/",
+        "sudo mv /home/centos/first-boot-centos.sh /usr/local/bin/first-boot.sh",
+        "mv cluster-localhost.yml kubevirt-ansible/playbooks/cluster/kubernetes",
+        "sudo systemctl daemon-reload",
+        "sudo systemctl enable kubevirt-installer",
+        "sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
+        "sudo yum install -y ansible docker jq bind-utils bind-libs cockpit wget git",
+        "sudo yum update -y",
+        "rm multus-config.yml"
+      ]
     }
   ],
   "post-processors": [

--- a/kubevirt-gcp-centos.json
+++ b/kubevirt-gcp-centos.json
@@ -27,68 +27,35 @@
   ],
   "provisioners": [
     {
-      "type": "file",
-      "source": "image-files/kubevirt-ansible",
-      "destination": "/home/centos"
+      "type": "shell-local",
+      "command": "tar czf ./image-files/kubevirt-ansible.tar.gz kubevirt-ansible"
     },
     {
       "type": "file",
-      "source": "image-files/cluster-wait.yml",
+      "source": "image-files",
       "destination": "/home/centos/"
     },
     {
-      "type": "file",
-      "source": "image-files/virtctl",
-      "destination": "/home/centos/"
-    },
-    {
-      "type": "file",
-      "source": "image-files/kubevirt-installer.service",
-      "destination": "/home/centos/"
+      "type": "shell-local",
+      "command": "rm ./image-files/kubevirt-ansible.tar.gz"
     },
     {
       "type": "shell",
-      "inline": "sudo mv /home/centos/kubevirt-installer.service /usr/lib/systemd/system/"
-    },
-    {
-      "type": "file",
-      "source": "image-files/first-boot-centos.sh",
-      "destination": "/home/centos/first-boot.sh"
-    },
-    {
-      "type": "shell",
-      "inline": "sudo mv /home/centos/first-boot.sh /usr/local/bin/"
-    },
-    {
-      "type": "shell",
-      "inline": "sudo systemctl daemon-reload"
-    },
-    {
-      "type": "shell",
-      "inline": "sudo systemctl enable kubevirt-installer"
-    },
-    {
-      "type": "shell",
-      "inline": "sudo yum install -y ansible docker jq bind-utils bind-libs cockpit wget git"
-    },
-    {
-      "type": "shell",
-      "inline": "sudo yum update -y"
-    },
-    {
-      "type": "file",
-      "source": "image-files/motd.j2",
-      "destination": "/home/centos/"
-    },
-    {
-      "type": "file",
-      "source": "image-files/motd.yml",
-      "destination": "/home/centos/"
-    },
-    {
-      "type": "file",
-      "source": "image-files/emulation-configmap.yaml",
-      "destination": "/home/centos/"
+      "inline": [
+        "mv image-files/* .",
+        "rmdir image-files",
+        "tar xzf kubevirt-ansible.tar.gz",
+        "rm kubevirt-ansible.tar.gz",
+        "sudo mv /home/centos/kubevirt-installer.service /usr/lib/systemd/system/",
+        "sudo mv /home/centos/first-boot-centos.sh /usr/local/bin/first-boot.sh",
+        "mv cluster-localhost.yml kubevirt-ansible/playbooks/cluster/kubernetes",
+        "sudo systemctl daemon-reload",
+        "sudo systemctl enable kubevirt-installer",
+        "sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
+        "sudo yum install -y ansible docker jq bind-utils bind-libs cockpit wget git",
+        "sudo yum update -y",
+        "rm multus-config.yml"
+      ]
     }
   ],
   "post-processors": [


### PR DESCRIPTION
The symbolic link at kubevirt-ansible/playbooks/role wasn't being 
preserved when the directory was copied to the EBS volume. Instead of a 
link, a copy of the directory represented by it was reproduced, 
duplicating code, and making it confusing as to where to edit roles.

As a solution, we now tar the contents of the kubevirt-ansible, copy the 
tar file over to the EBS volume, and extract it.