### PR TITLE
Add task to stop GCP instance before removing it

### DIFF
--- a/gcp-test-centos-cleanup.yml
+++ b/gcp-test-centos-cleanup.yml
@@ -8,6 +8,16 @@
     zone: "{{ lookup('env', 'ZONE') }}"
     service_account_email:  "{{ lookup('env', 'SERVICE_ACCOUNT_EMAIL') }}"
   tasks:
+    - name: Stop the test instance
+      gce:
+         instance_names: "{{ gcp_instance_name }}"
+         zone: "{{ zone }}"
+         image: kubevirt-button
+         state: stopped
+         service_account_email: "{{ service_account_email }}"
+         credentials_file: "{{ credentials_file }}"
+         project_id: "{{ project_id }}"
+
     - name: Delete the test instance
       gce:
          instance_names: "{{ gcp_instance_name }}"


### PR DESCRIPTION
Recently, setting the instance to "absent" times out in libcloud.
The instance does eventually get removed.

Stopping and then removing the instance avoids this time out issue.

Fixes: https://github.com/kubevirt/cloud-image-builder/issues/72