### PR TITLE
Update tests to use commands from kubevirt.io website

### DIFF
--- a/tests/cdi-lab.yml
+++ b/tests/cdi-lab.yml
@@ -6,58 +6,65 @@
   gather_facts: True
   tasks:
     # Tests for lab 2 CDI
+    - name: read in lab variables
+      include_vars:
+        file: labs_kubernetes_variables.yml
+        name: labs_vars
+
+    - debug: var=labs_vars
+
     - name: create hostpath storage class
-      command: kubectl apply -f https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/labs/manifests/storage-setup.yml
+      command: kubectl apply -f {{ labs_vars.cdi_lab.storage_setup_manifest }}
 
     - name: create cdi
-      command: kubectl apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/v1.3.0/cdi-controller.yaml
+      command: kubectl apply -f {{ labs_vars.cdi_lab.cdi_controller_manifest }}
 
     - name: wait for cdi-deployment pod to become Running
-      shell: kubectl get pods -n kube-system | grep cdi-deployment
+      shell: "{{ labs_vars.cdi_lab.cdi_pod_listing_command }} | grep cdi-deployment"
       register: cdi_deployment_status
       until: cdi_deployment_status.stdout.find("Running") != -1
       retries: 30
       delay: 10
 
     - name: deploy fedora pvc
-      command: kubectl apply -f https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/labs/manifests/pvc_fedora.yml
+      command: kubectl apply -f {{ labs_vars.cdi_lab.pvc_manifest }}
 
     - name: wait for fedora pvc to become Bound
-      shell: kubectl get pvc | grep fedora
+      shell: kubectl get pvc | grep {{ labs_vars.cdi_lab.pvc_name }}
       register: fedora_pvc_status
       until: fedora_pvc_status.stdout.find("Bound") != -1
       retries: 12
       delay: 5
 
     - name: wait for importer pod to start running
-      shell: kubectl get pods | grep importer-fedora
+      shell: kubectl get pods | grep importer-{{ labs_vars.cdi_lab.pvc_name }}
       register: fedora_importer_status
       until: fedora_importer_status.stdout.find("Running") != -1
       retries: 12
       delay: 5
 
     - name: wait for importer pod to succeed
-      shell: kubectl describe pvc fedora | grep "cdi.kubevirt.io/storage.pod.phase"
+      shell: kubectl describe pvc {{ labs_vars.cdi_lab.pvc_name }} | grep "cdi.kubevirt.io/storage.pod.phase"
       register: fedora_importer_status
       until: fedora_importer_status.stdout.find("Succeeded") != -1
       retries: 12
       delay: 5
 
     - name: create fedora vm
-      command: kubectl create -f https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/labs/manifests/vm1_pvc.yml
+      command: kubectl create -f {{ labs_vars.cdi_lab.vm_manifest }}
 
     - name: wait for fedora vm to be Running
-      shell: kubectl describe vmi vm1 | grep Phase
+      shell: kubectl describe vmi {{ labs_vars.cdi_lab.vm_name }} | grep Phase
       register: vm1_status
       until: vm1_status.stdout.find("Running") != -1
       retries: 30
       delay: 10
 
     - name: use virtctl to stop VM
-      command: /home/centos/virtctl stop vm1
+      command: /home/centos/virtctl stop {{ labs_vars.cdi_lab.vm_name }}
 
     - name: delete vm1
-      command: kubectl delete vm vm1
+      command: kubectl delete vm {{ labs_vars.cdi_lab.vm_name }}
 
     - name: wait for fedora vmi to be removed
       shell: kubectl get vmi
@@ -67,17 +74,17 @@
       delay: 10
 
     - name: delete fedora pvc
-      command: kubectl delete pvc fedora
+      command: kubectl delete pvc {{ labs_vars.cdi_lab.pvc_name }}
 
     - name: wait for fedora pvc to be removed
       shell: kubectl get pvc
       register: pvc_status
-      until: pvc_status.stdout.find("fedora") == -1
+      until: pvc_status.stderr.find("No resources") != -1
       retries: 30
       delay: 10
 
     - name: delete cdi
-      command: kubectl delete -f https://github.com/kubevirt/containerized-data-importer/releases/download/v1.3.0/cdi-controller.yaml
+      command: kubectl delete -f {{ labs_vars.cdi_lab.cdi_controller_manifest }}
 
     - name: delete hostpath storage class
-      command: kubectl delete -f https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/master/labs/manifests/storage-setup.yml
+      command: kubectl delete -f {{ labs_vars.cdi_lab.storage_setup_manifest }}

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -1,2 +1,10 @@
+- name: Run tests against image
+  hosts: localhost
+  tasks:
+    - name: fetch lab variables from kubevirt.io repo
+      get_url:
+        url: https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/5ef9e91f52b65f54635a54dbbbefb5f00cc2f209/_data/labs_kubernetes_variables.yml
+        dest: ./labs_kubernetes_variables.yml
+
 - include: use-kubevirt-lab.yml
 - include: cdi-lab.yml

--- a/tests/use-kubevirt-lab.yml
+++ b/tests/use-kubevirt-lab.yml
@@ -4,63 +4,35 @@
   become: True
   gather_facts: True
   tasks:
-    - name: copy yaml files
-      copy:
-        src: ../manifests/
-        dest: /home/centos/manifests/
-        owner: centos
-        group: centos
+    - name: read in lab variables
+      include_vars:
+        file: labs_kubernetes_variables.yml
+        name: labs_vars
 
-    - name: create hostpath storage class
-      command: kubectl apply -f /home/centos/manifests/storage-setup.yaml
+    - debug: var=labs_vars
 
-    - name: create cdi provisioner
-      command: ansible-playbook -i inventory-aws -e apb_action=provision -e cdi_image_namespace=golden --connection=local playbooks/cdi.yml
-      args:
-        chdir: /home/centos/kubevirt-ansible
-
-    - name: wait for cdi-deployment pod to become Running
-      shell: kubectl get pods -n golden | grep cdi-deployment
-      register: cdi_deployment_status
-      until: cdi_deployment_status.stdout.find("Running") != -1
-      retries: 30
-      delay: 10
-
-    - name: deploy pvc
-      command: kubectl apply -f /home/centos/manifests/cirros-pvc.yaml
-
-    - name: wait for cirros-pvc to become Bound
-      shell: kubectl get pvc | grep cirros-pvc
-      register: cirros_pvc_status
-      until: cirros_pvc_status.stdout.find("Bound") != -1
-      retries: 12
-      delay: 5
-
-    - name: deploy cirros vm
-      command: kubectl apply -f /home/centos/manifests/cirros-vm.yaml
+    - name: create vm
+      command: kubectl apply -f {{ labs_vars.use_kubevirt_lab.vm_manifest }}
 
     - name: use virtctl to start VM
-      command: /home/centos/virtctl start cirros-vm
+      command: /home/centos/virtctl start {{ labs_vars.use_kubevirt_lab.vm_name }}
 
-    - name: wait for cirros vm to be Running
-      shell: kubectl describe vmi cirros-vm | grep Phase
-      register: cirros_vm_status
-      until: cirros_vm_status.stdout.find("Running") != -1
+    - name: wait for vm to be Running
+      shell: kubectl describe vmi {{ labs_vars.use_kubevirt_lab.vm_name }} | grep Phase
+      register: vm_status
+      until: vm_status.stdout.find("Running") != -1
       retries: 30
       delay: 10
 
     - name: use virtctl to stop VM
-      command: /home/centos/virtctl stop cirros-vm
+      command: /home/centos/virtctl stop  {{ labs_vars.use_kubevirt_lab.vm_name }}
 
-    - name: wait for cirros vmi to be removed
+    - name: wait for vmi to be removed
       shell: kubectl get vmi
-      register: cirros_vm_status
-      until: cirros_vm_status.stderr.find("No resources") != -1
+      register: vm_status
+      until: vm_status.stderr.find("No resources") != -1
       retries: 30
       delay: 10
 
-    - name: remove cdi
-      command: kubectl delete -f /tmp/cdi-provision.yml
-
-    - name: remove hostpath storage class
-      command: kubectl delete -f /home/centos/manifests/storage-setup.yaml
+    - name: cleanup vm
+      command: kubectl delete -f {{ labs_vars.use_kubevirt_lab.vm_manifest }}


### PR DESCRIPTION
We want tighter integration between the commands the users are using in 
the labs and the commands we execute in the CI tests.

Parts of the commands used in the kubernetes lab on kubevirt.io have 
been templated out into the labs_kuberentes_variables.yml file. This 
change updates the tests to read in the variables from this file and 
then use the variables to form test commands.