### PR TITLE
Shutdown instance after tests are complete

### DIFF
--- a/gcp-test-centos-cleanup.yml
+++ b/gcp-test-centos-cleanup.yml
@@ -8,6 +8,23 @@
     zone: "{{ lookup('env', 'ZONE') }}"
     service_account_email:  "{{ lookup('env', 'SERVICE_ACCOUNT_EMAIL') }}"
   tasks:
+    - name: wait for instance to shutdown
+      gcp_compute_instance_facts:
+        zone: "{{ zone }}"
+        filters:
+          - name = "{{ gcp_instance_name }}"
+        auth_kind: "serviceaccount"
+        service_account_file: "{{ credentials_file }}"
+        project: "{{ project_id }}"
+        scopes:
+          - https://www.googleapis.com/auth/compute
+      register: instance_status
+      until: instance_status['items'][0].status.find("TERMINATED") != -1
+      retries: 60
+      delay: 15
+
+    - debug: var=instance_status
+
     - name: Delete the test instance
       gce:
          instance_names: "{{ gcp_instance_name }}"

--- a/tests/test-instance-shutdown.yml
+++ b/tests/test-instance-shutdown.yml
@@ -1,0 +1,9 @@
+- name: shutdown instance
+  hosts: launched
+  user: centos
+  become: True
+  gather_facts: True
+  tasks:
+    - name: shutdown instance
+      command: shutdown -h +1
+      become_user: root

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -1,2 +1,3 @@
 - include: use-kubevirt-lab.yml
 - include: cdi-lab.yml
+- include: test-instance-shutdown.yml


### PR DESCRIPTION
Needed to speed up GCP instance delete. GCP deletes are timing out
because it is taking longer than 180s.