### PR TITLE
Add checks for virt-handler pod and virt-api service

### DIFF
--- a/tests/pretest-checks.yml
+++ b/tests/pretest-checks.yml
@@ -17,3 +17,17 @@
       until: virt_controller_pod_status.stdout.find("Running") != -1
       retries: 12
       delay: 5
+
+    - name: wait for virt-handler pod to be running
+      shell: kubectl get pods -n kube-system | grep virt-handler
+      register: virt_handler_pod_status
+      until: virt_handler_pod_status.stdout.find("Running") != -1
+      retries: 12
+      delay: 5
+
+    - name: wait for virt-api service to be up
+      shell: kubectl get services -n kube-system
+      register: services_status
+      until: services_status.stdout.find("virt-api") != -1
+      retries: 12
+      delay: 5

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -6,7 +6,7 @@
         url: https://raw.githubusercontent.com/kubevirt/kubevirt.github.io/5ef9e91f52b65f54635a54dbbbefb5f00cc2f209/_data/labs_kubernetes_variables.yml
         dest: ./labs_kubernetes_variables.yml
 
-- include: pods-check.yml
+- include: pretest-checks.yml
 - include: use-kubevirt-lab.yml
 - include: cdi-lab.yml
 - include: test-instance-shutdown.yml


### PR DESCRIPTION
Should wait for virt-handler to be running and virt-api service
to be available before executing tests.