### PR TITLE
Create after-install-checks.yml from pretest-checks.yml

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,8 +21,6 @@ export KUBEVIRT_VERSION=$(cat kubevirt-ansible/vars/all.yml | grep version | gre
 cd image-files
 [ -f virtctl ] || curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v$KUBEVIRT_VERSION/virtctl-v$KUBEVIRT_VERSION-linux-amd64
 chmod +x virtctl
-
-cp ../tests/pretest-checks.yml .
 cd ..
 
 echo $KUBEVIRT_VERSION > kubevirt-version

--- a/image-files/after-install-checks.yml
+++ b/image-files/after-install-checks.yml
@@ -1,0 +1,44 @@
+- name: check that KubeVirt pods are up before running tests
+  hosts: masters
+  user: centos
+  become: True
+  gather_facts: True
+  tasks:
+    - name: wait for virt-api pod to be running
+      shell: kubectl get pods -n kube-system | grep virt-api
+      register: virt_api_pod_status
+      until: virt_api_pod_status.stdout.find("Running") != -1
+      retries: 12
+      delay: 5
+
+    - name: wait for virt-controller pod to be running
+      shell: kubectl get pods -n kube-system | grep virt-controller
+      register: virt_controller_pod_status
+      until: virt_controller_pod_status.stdout.find("Running") != -1
+      retries: 12
+      delay: 5
+
+    - name: wait for virt-handler pod to be running
+      shell: kubectl get pods -n kube-system | grep virt-handler
+      register: virt_handler_pod_status
+      until: virt_handler_pod_status.stdout.find("Running") != -1
+      retries: 12
+      delay: 5
+
+    - name: wait for virt-api service to be up
+      shell: kubectl get services -n kube-system
+      register: services_status
+      until: services_status.stdout.find("virt-api") != -1
+      retries: 12
+      delay: 5
+
+    - name: query virt-api's clusterIP
+      shell: kubectl get services virt-api -n kube-system  -o yaml | grep clusterIP | cut -f 4 -d " "
+      register: virt_api_cluster_ip
+
+    - debug: var=virt_api_cluster_ip
+
+    - name: wait for virt_api port 443 to be open
+      wait_for:
+        host: "{{ virt_api_cluster_ip.stdout }}"
+        port: 443

--- a/image-files/first-boot-centos.sh
+++ b/image-files/first-boot-centos.sh
@@ -31,9 +31,8 @@ grep -q -E 'vmx|svm' /proc/cpuinfo || kubectl apply -f /home/centos/emulation-co
 sudo ansible-playbook playbooks/kubevirt.yml -e@vars/all.yml -e cluster=kubernetes --connection=local -i inventory-aws
 
 # validate kubevirt pods and services are up
-cd /home/centos
-sudo ansible-playbook pretest-checks.yml --connection=local -i inventory-aws
-rm pretest-checks.yml
+mv /home/centos/after-install-checks.yml .
+sudo ansible-playbook after-install-checks.yml --connection=local -i inventory-aws
 
 # remove CDI because users will create it as a lab exercise
 kubectl delete -f /tmp/cdi-provision.yml


### PR DESCRIPTION
Cannot use pretest-checks.yml in first-boot-centos.sh because the
inventory file uses "masters" instead of "launched" for launched hosts.