### PR TITLE
[WIP] KubeVirt 0.13.0 updates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,25 +4,25 @@ set -x
 if [ ! -d kubevirt-ansible ]; then
   git clone https://github.com/kubevirt/kubevirt-ansible
 
-  sed -i "s@kubectl taint nodes {{ ansible_fqdn }} node-role.kubernetes.io/master:NoSchedule- || :@kubectl taint nodes --all node-role.kubernetes.io/master-@"  kubevirt-ansible/roles/kubernetes-master/templates/deploy_kubernetes.j2
+  sed -i.bak "s@kubectl taint nodes {{ ansible_fqdn }} node-role.kubernetes.io/master:NoSchedule- || :@kubectl taint nodes --all node-role.kubernetes.io/master-@"  kubevirt-ansible/roles/kubernetes-master/templates/deploy_kubernetes.j2
 
-  # set specific kubevirt version
-  sed -i 's@version: 0.9.6@version: 0.11.0@' kubevirt-ansible/vars/all.yml
+  # set platform
+  sed -i.bak "s/platform: openshift/platform: kubernetes/" kubevirt-ansible/vars/all.yml
 
   #Fix for missing {{ }}
-  sed -i "s/weavenet.stdout/\"{{ weavenet.stdout }}\"/" kubevirt-ansible/roles/kubernetes-master/tasks/main.yml
+  sed -i.bak "s/weavenet.stdout/\"{{ weavenet.stdout }}\"/" kubevirt-ansible/roles/kubernetes-master/tasks/main.yml
 
-  # Fix for bad determination of openshift environment
-  cp ./patches/kubevirt.yml kubevirt-ansible/playbooks
-  cp ./patches/provision.yml kubevirt-ansible/roles/kubevirt/tasks
 fi
 
-export KUBEVIRT_VERSION=$(cat kubevirt-ansible/vars/all.yml | grep version | grep -v _ver | cut -f 2 -d ' ')
+export KUBEVIRT_VERSION=0.13.0
 cd image-files
+# used during first-boot to decide which version of KubeVirt to install
+echo $KUBEVIRT_VERSION > kubevirt-version
 [ -f virtctl ] || curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v$KUBEVIRT_VERSION/virtctl-v$KUBEVIRT_VERSION-linux-amd64
 chmod +x virtctl
 cd ..
 
+# for use by gcp image publish
 echo $KUBEVIRT_VERSION > kubevirt-version
 pwd
 

--- a/image-files/after-install-checks.yml
+++ b/image-files/after-install-checks.yml
@@ -5,35 +5,35 @@
   gather_facts: True
   tasks:
     - name: wait for virt-api pod to be running
-      shell: kubectl get pods -n kube-system | grep virt-api
+      shell: kubectl get pods -n kubevirt | grep virt-api
       register: virt_api_pod_status
       until: virt_api_pod_status.stdout.find("Running") != -1
       retries: 12
       delay: 5
 
     - name: wait for virt-controller pod to be running
-      shell: kubectl get pods -n kube-system | grep virt-controller
+      shell: kubectl get pods -n kubevirt | grep virt-controller
       register: virt_controller_pod_status
       until: virt_controller_pod_status.stdout.find("Running") != -1
       retries: 12
       delay: 5
 
     - name: wait for virt-handler pod to be running
-      shell: kubectl get pods -n kube-system | grep virt-handler
+      shell: kubectl get pods -n kubevirt | grep virt-handler
       register: virt_handler_pod_status
       until: virt_handler_pod_status.stdout.find("Running") != -1
       retries: 12
       delay: 5
 
     - name: wait for virt-api service to be up
-      shell: kubectl get services -n kube-system
+      shell: kubectl get services -n kubevirt
       register: services_status
       until: services_status.stdout.find("virt-api") != -1
       retries: 12
       delay: 5
 
     - name: query virt-api's clusterIP
-      shell: kubectl get services virt-api -n kube-system  -o yaml | grep clusterIP | cut -f 4 -d " "
+      shell: kubectl get services virt-api -n kubevirt  -o yaml | grep clusterIP | cut -f 4 -d " "
       register: virt_api_cluster_ip
 
     - debug: var=virt_api_cluster_ip

--- a/image-files/motd.yml
+++ b/image-files/motd.yml
@@ -11,9 +11,7 @@
       register: kubernetes_version
 
     - name: find KubeVirt version
-      shell: |
-        cat kubevirt-ansible/vars/all.yml  |
-        grep version | grep -v openshift | awk '{ print $2 }'
+      shell: cat /home/centos/kubevirt-version
       register: kubevirt_version
 
     - name: template motd file

--- a/kubevirt-ami-centos.json
+++ b/kubevirt-ami-centos.json
@@ -56,7 +56,6 @@
         "sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
         "sudo yum install -y ansible docker jq bind-utils bind-libs cockpit wget git",
         "sudo yum update -y",
-        "sudo yum downgrade docker docker-common docker-client -y",
         "rm multus-config.yml"
       ]
     }

--- a/kubevirt-gcp-centos.json
+++ b/kubevirt-gcp-centos.json
@@ -53,7 +53,6 @@
         "sudo systemctl enable kubevirt-installer",
         "sudo yum install -y ansible docker jq bind-utils bind-libs cockpit wget git",
         "sudo yum update -y",
-        "sudo yum downgrade docker docker-common docker-client -y",
         "rm multus-config.yml"
       ]
     }

--- a/tests/pretest-checks.yml
+++ b/tests/pretest-checks.yml
@@ -5,35 +5,35 @@
   gather_facts: True
   tasks:
     - name: wait for virt-api pod to be running
-      shell: kubectl get pods -n kube-system | grep virt-api
+      shell: kubectl get pods -n kubevirt | grep virt-api
       register: virt_api_pod_status
       until: virt_api_pod_status.stdout.find("Running") != -1
       retries: 12
       delay: 5
 
     - name: wait for virt-controller pod to be running
-      shell: kubectl get pods -n kube-system | grep virt-controller
+      shell: kubectl get pods -n kubevirt | grep virt-controller
       register: virt_controller_pod_status
       until: virt_controller_pod_status.stdout.find("Running") != -1
       retries: 12
       delay: 5
 
     - name: wait for virt-handler pod to be running
-      shell: kubectl get pods -n kube-system | grep virt-handler
+      shell: kubectl get pods -n kubevirt | grep virt-handler
       register: virt_handler_pod_status
       until: virt_handler_pod_status.stdout.find("Running") != -1
       retries: 12
       delay: 5
 
     - name: wait for virt-api service to be up
-      shell: kubectl get services -n kube-system
+      shell: kubectl get services -n kubevirt
       register: services_status
       until: services_status.stdout.find("virt-api") != -1
       retries: 12
       delay: 5
 
     - name: query virt-api's clusterIP
-      shell: kubectl get services virt-api -n kube-system  -o yaml | grep clusterIP | cut -f 4 -d " "
+      shell: kubectl get services virt-api -n kubevirt  -o yaml | grep clusterIP | cut -f 4 -d " "
       register: virt_api_cluster_ip
 
     - debug: var=virt_api_cluster_ip


### PR DESCRIPTION
Installs KubeVirt directly using operator manifests instead of
kubevirt-ansible. kubevirt-ansible is still used to install the
kubernetes cluster.

Starting with v0.12.0, KubeVirt is installed in the kubevirt
namespace. Previously, it was installed in the kube-system
namespace. Updated tests to use kubevirt namespace.