### PR TITLE
add a symlink to the admin.conf in the kube default location

### DIFF
--- a/image-files/first-boot-centos.sh
+++ b/image-files/first-boot-centos.sh
@@ -17,9 +17,15 @@ sudo ansible-playbook playbooks/cluster/kubernetes/cluster-localhost.yml --conne
 
 # enable kubectl for centos user
 sudo cp /etc/kubernetes/admin.conf /home/centos
+sudo ln -s ./admin.conf /home/centos
 sudo chown centos:centos /home/centos/admin.conf
 export KUBECONFIG=/home/centos/admin.conf
 echo "export KUBECONFIG=~/admin.conf" >> /home/centos/.bash_profile
+
+# Put the kubeconfig in the default place for SSH without a TTY (and profile) 
+sudo mkdir /home/centos/.kube
+sudo ln --symbolic ../admin.conf /home/centos/.kube/config
+sudo chown --recursive centos:centos /home/centos/.kube
 
 # wait for kubernetes cluster to be up
 sudo ansible-playbook /home/centos/cluster-wait.yml --connection=local


### PR DESCRIPTION
This change adds a symlink where kubectl expects the default config to exist. This symlink points to the actual location, /home/centos/admin.conf.

This change allows scripts that access the instance by SSH but do not create an interactive session (and hence a TTY) to successfully execute kubectl commands without having to specify the location of the file in the CLI arguments.