### PR TITLE
Updating gitignore and adding binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 kubevirt-ansible
+virtctl
+kubectl

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 kubevirt-ansible
-virtctl

--- a/shell/build.sh
+++ b/shell/build.sh
@@ -2,6 +2,14 @@
 
 set -x
 
+  ## Download the static binaries that ansible will assume to already exist
+rm -f bin/virtctl
+wget https://github.com/kubevirt/kubevirt/releases/download/v${KUBEVIRT_VERSION}/virtctl-v${KUBEVIRT_VERSION}-linux-amd64 -O bin/virtctl
+
+rm -f bin/kubectl
+curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl -o bin/kubectl
+
+  ## Execute required playbooks
 ansible-playbook ansible/${targetEnvironment}-provision.yml > ansible-provision-${targetEnvironment}.log 2>&1
 ansible-playbook --private-key ${SSH_KEY_LOCATION} -i /tmp/inventory ansible/${targetEnvironment}-setup.yml > ansible-setup-${targetEnvironment}.log 2>&1
 ansible-playbook --private-key ${SSH_KEY_LOCATION} -i /tmp/inventory ansible/${targetEnvironment}-mkimage.yml > ansible-mkimage-${targetEnvironment}.log 2>&1


### PR DESCRIPTION
This hopefully resolves #123 

the underlying issue is that the static binaries aren't included in the git repo. I know it looks weird but the binaries are static and don't seem to change often enough for the online labs to break. Housing them in the main git repo ensure availability rather than depending upon some sort of approach in the pipeline execution where it programmatically determines that latest binary. Downloading it programmatically would always catch the latest code but runs the risk of the code breaking somehow since it depends upon things like URL's that we don't control remaining the same. This way it's all housed in a single repo that we do control.